### PR TITLE
Set a "real" version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(fname):
 if sys.platform == 'win32':
 	setup(
 		name = "reposado",
-		version = "git",
+		version = "0.0+git",
 		author = "Greg Neagle",
 		author_email = "reposado@googlegroups.com",
 		maintainer = "Brent B",
@@ -41,7 +41,7 @@ if sys.platform == 'win32':
 else:
 	setup(
 		name = "reposado",
-		version = "git",
+		version = "0.0+git",
 		author = "Greg Neagle",
 		author_email = "reposado@googlegroups.com",
 		maintainer = "Brent B",


### PR DESCRIPTION
Newer versions of python don't like "git" as a version:
```
/usr/lib/python3/dist-packages/setuptools/dist.py:548: UserWarning: The version specified ('git') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
```